### PR TITLE
User says no

### DIFF
--- a/src/main/java/spring/app/configuration/DownloadMusicServiceFactory.java
+++ b/src/main/java/spring/app/configuration/DownloadMusicServiceFactory.java
@@ -9,7 +9,9 @@ import org.springframework.context.annotation.PropertySource;
 import spring.app.service.abstraction.DownloadMusicService;
 import spring.app.service.impl.musicSearcher.MusicSearchServiceImpl;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -73,7 +75,7 @@ public class DownloadMusicServiceFactory {
     private DownloadMusicService downloadMusicVkRuServiceImpl;
 
     // поле изменил на LinkedHashSet, чтобы исключить дублирование сервисов в коллекции
-    private Set<DownloadMusicService> services = new LinkedHashSet<>();
+    private List<DownloadMusicService> services = new ArrayList<>();
 
 
     public DownloadMusicServiceFactory() {
@@ -154,7 +156,7 @@ public class DownloadMusicServiceFactory {
      * Метод, формирующий список сервисов, которые поочередно используются в поиске трека
      * в классе {@link MusicSearchServiceImpl}
      */
-    public Set<DownloadMusicService> getDownloadServices() {
+    public List<DownloadMusicService> getDownloadServices() {
         try {
             services.clear();
             services.add(getService(one));

--- a/src/main/java/spring/app/configuration/WebConfig.java
+++ b/src/main/java/spring/app/configuration/WebConfig.java
@@ -1,12 +1,16 @@
 package spring.app.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import java.io.File;
+import java.time.Duration;
 
 
 @Configuration
@@ -32,6 +36,14 @@ public class WebConfig extends WebMvcConfigurerAdapter {
                         "classpath:/static/js/",
                         "classpath:/static/spa/",
                         "file:" + coversDir + File.separator);
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+                .setConnectTimeout(3000)
+                .setReadTimeout(3000)
+                .build();
     }
 
     //add new controller

--- a/src/main/java/spring/app/configuration/initializer/TestDataInit.java
+++ b/src/main/java/spring/app/configuration/initializer/TestDataInit.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import spring.app.configuration.DownloadMusicServiceConfigurer;
 import spring.app.configuration.DownloadMusicServiceConfigurerMBean;
 import spring.app.configuration.DownloadMusicServiceFactory;
+import spring.app.dao.abstraction.CounterDao;
 import spring.app.dto.SongCompilationDto;
 import spring.app.model.*;
 import spring.app.service.abstraction.*;
@@ -84,6 +85,9 @@ public class TestDataInit {
     private NotificationTemplateService notificationTemplateService;
 
     @Autowired
+    private CounterDao counterDao;
+
+    @Autowired
     private Mp3Parser mp3Parser;
 
     @Value("${music.path}")
@@ -93,6 +97,9 @@ public class TestDataInit {
     private String musicInitPath;
 
     private void init() throws Exception {
+
+        //создаем и запускаем счетчик для музыкальных сервисов
+        counterDao.start(CounterType.DOWNLOAD_MUSIC_SERVICE);
 
         // Создаем роли
         Role roleAdmin = new Role("ADMIN");

--- a/src/main/java/spring/app/configuration/initializer/TestDataInit.java
+++ b/src/main/java/spring/app/configuration/initializer/TestDataInit.java
@@ -85,9 +85,6 @@ public class TestDataInit {
     private NotificationTemplateService notificationTemplateService;
 
     @Autowired
-    private CounterDao counterDao;
-
-    @Autowired
     private Mp3Parser mp3Parser;
 
     @Value("${music.path}")
@@ -97,9 +94,6 @@ public class TestDataInit {
     private String musicInitPath;
 
     private void init() throws Exception {
-
-        //создаем и запускаем счетчик для музыкальных сервисов
-        counterDao.start(CounterType.DOWNLOAD_MUSIC_SERVICE);
 
         // Создаем роли
         Role roleAdmin = new Role("ADMIN");

--- a/src/main/java/spring/app/controller/restController/TelegramRestController.java
+++ b/src/main/java/spring/app/controller/restController/TelegramRestController.java
@@ -30,12 +30,12 @@ public class TelegramRestController {
     private final static Logger LOGGER = LoggerFactory.getLogger(TelegramRestController.class);
     private final OrderSongService orderSongService;
     private final TelegramService telegramService;
-    private SongService songService;
-    private CompanyService companyService;
-    private SongQueueService songQueueService;
-    private AddressService addressService;
-    private TelegramUserService telegramUserService;
-    private VisitService visitService;
+    private final SongService songService;
+    private final CompanyService companyService;
+    private final SongQueueService songQueueService;
+    private final AddressService addressService;
+    private final TelegramUserService telegramUserService;
+    private final VisitService visitService;
 
     @Autowired
     public TelegramRestController(TelegramService telegramService,
@@ -143,7 +143,8 @@ public class TelegramRestController {
         long songId = Long.parseLong(headers.get("songId").get(0));
         long companyId = Long.parseLong(headers.get("companyId").get(0));
         LOGGER.info("Provided songId = {} and companyId = {}", songId, companyId);
-        // получаем песню, компанию и очередь компании из базы
+        // получаем песню, компанию и очередь компании из базы и обнуляем счетчик сервиса для песни
+        songService.resetSongCounter(songId);
         Song songById = songService.getById(songId);
         Company companyById = companyService.getById(companyId);
         SongQueue songQueue = songQueueService.getSongQueueBySongAndCompany(songById, companyById);

--- a/src/main/java/spring/app/dao/abstraction/CounterDao.java
+++ b/src/main/java/spring/app/dao/abstraction/CounterDao.java
@@ -1,15 +1,12 @@
 package spring.app.dao.abstraction;
 
-import spring.app.model.Counter;
-import spring.app.model.CounterType;
-
 public interface CounterDao {
 
-    void start(CounterType counterType);
+    void start(String counterType);
 
-    Counter restart(CounterType counterType);
+    int restart(String counterType);
 
-    void setTo(CounterType counterType, int value);
+    void setTo(String counterType, int value);
 
-    int getValue(CounterType counterType);
+    int getValue(String counterType);
 }

--- a/src/main/java/spring/app/dao/abstraction/CounterDao.java
+++ b/src/main/java/spring/app/dao/abstraction/CounterDao.java
@@ -1,0 +1,15 @@
+package spring.app.dao.abstraction;
+
+import spring.app.model.Counter;
+import spring.app.model.CounterType;
+
+public interface CounterDao {
+
+    void start(CounterType counterType);
+
+    Counter restart(CounterType counterType);
+
+    void setTo(CounterType counterType, int value);
+
+    int getValue(CounterType counterType);
+}

--- a/src/main/java/spring/app/dao/abstraction/dto/SongDtoDao.java
+++ b/src/main/java/spring/app/dao/abstraction/dto/SongDtoDao.java
@@ -8,4 +8,5 @@ public interface SongDtoDao {
 
     List<SongDto> getAll();
 
+    SongDto getById(long songId);
 }

--- a/src/main/java/spring/app/dao/impl/CounterDaoImpl.java
+++ b/src/main/java/spring/app/dao/impl/CounterDaoImpl.java
@@ -1,0 +1,51 @@
+package spring.app.dao.impl;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import spring.app.dao.abstraction.CounterDao;
+import spring.app.model.Counter;
+import spring.app.model.CounterType;
+
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.PersistenceContext;
+
+@Repository
+public class CounterDaoImpl implements CounterDao {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void start(CounterType counterType) {
+        Counter temp = new Counter(counterType, 0);
+        entityManager.persist(temp);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW,
+            isolation = Isolation.READ_COMMITTED)
+    public Counter restart(CounterType counterType) {
+        Counter temp = new Counter(counterType, 0);
+        return entityManager.merge(temp);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW,
+            isolation = Isolation.READ_COMMITTED)
+    public void setTo(CounterType counterType, int value) {
+        Counter temp = new Counter(counterType, value);
+        entityManager.merge(temp);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW,
+            isolation = Isolation.READ_COMMITTED)
+    public int getValue(CounterType counterType) {
+        Counter temp = entityManager.find(Counter.class, counterType, LockModeType.PESSIMISTIC_READ);
+        return temp.getValue();
+    }
+}

--- a/src/main/java/spring/app/dao/impl/dto/SongDtoDaoImpl.java
+++ b/src/main/java/spring/app/dao/impl/dto/SongDtoDaoImpl.java
@@ -24,4 +24,14 @@ public class SongDtoDaoImpl implements SongDtoDao {
 
         return songDtos;
     }
+
+    @Override
+    public SongDto getById(long songId) {
+        return entityManager.createQuery("SELECT new spring.app.dto.SongDto(s.id, s.name, s.isApproved, s.author.name, s.genre.name) " +
+                "FROM Song s where s.id = :id", SongDto.class)
+                .setParameter("id", songId)
+                .setMaxResults(1)
+                .getResultList()
+                .get(0);
+    }
 }

--- a/src/main/java/spring/app/model/Counter.java
+++ b/src/main/java/spring/app/model/Counter.java
@@ -1,0 +1,44 @@
+package spring.app.model;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "t_counter")
+public class Counter {
+    @Id
+    @Enumerated(EnumType.STRING)
+    private CounterType counterType;
+
+    @Column(name = "value")
+    private Integer value;
+
+    public Counter() {
+
+    }
+
+    public Counter(CounterType counterType) {
+        this.counterType = counterType;
+    }
+
+    public Counter(CounterType counterType, Integer value) {
+        this.counterType = counterType;
+        this.value = value;
+    }
+
+
+    public CounterType getCounterType() {
+        return counterType;
+    }
+
+    public void setCounterType(CounterType counterType) {
+        this.counterType = counterType;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/spring/app/model/Counter.java
+++ b/src/main/java/spring/app/model/Counter.java
@@ -6,8 +6,7 @@ import javax.persistence.*;
 @Table(name = "t_counter")
 public class Counter {
     @Id
-    @Enumerated(EnumType.STRING)
-    private CounterType counterType;
+    private String counterType;
 
     @Column(name = "value")
     private Integer value;
@@ -16,21 +15,21 @@ public class Counter {
 
     }
 
-    public Counter(CounterType counterType) {
+    public Counter(String counterType) {
         this.counterType = counterType;
     }
 
-    public Counter(CounterType counterType, Integer value) {
+    public Counter(String counterType, Integer value) {
         this.counterType = counterType;
         this.value = value;
     }
 
 
-    public CounterType getCounterType() {
+    public String getCounterType() {
         return counterType;
     }
 
-    public void setCounterType(CounterType counterType) {
+    public void setCounterType(String counterType) {
         this.counterType = counterType;
     }
 

--- a/src/main/java/spring/app/model/CounterType.java
+++ b/src/main/java/spring/app/model/CounterType.java
@@ -1,5 +1,0 @@
-package spring.app.model;
-
-public enum CounterType {
-    DOWNLOAD_MUSIC_SERVICE
-}

--- a/src/main/java/spring/app/model/CounterType.java
+++ b/src/main/java/spring/app/model/CounterType.java
@@ -1,0 +1,5 @@
+package spring.app.model;
+
+public enum CounterType {
+    DOWNLOAD_MUSIC_SERVICE
+}

--- a/src/main/java/spring/app/service/abstraction/GenreDefinerService.java
+++ b/src/main/java/spring/app/service/abstraction/GenreDefinerService.java
@@ -3,5 +3,5 @@ package spring.app.service.abstraction;
 import java.io.IOException;
 
 public interface GenreDefinerService {
-    String[] defineGenre(String author) throws IOException;
+    String[] defineGenre(String trackAuthor, String trackSong) throws IOException;
 }

--- a/src/main/java/spring/app/service/abstraction/SongService.java
+++ b/src/main/java/spring/app/service/abstraction/SongService.java
@@ -39,4 +39,6 @@ public interface SongService extends GenericService<Long, Song>{
     Long getSongIdByAuthorAndName(String author, String name);
 
     Long getAuthorIdBySongId(Long songId);
+
+    void resetSongCounter(long songId);
 }

--- a/src/main/java/spring/app/service/impl/GenreDefinerServiceImpl.java
+++ b/src/main/java/spring/app/service/impl/GenreDefinerServiceImpl.java
@@ -1,16 +1,24 @@
 package spring.app.service.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import spring.app.service.abstraction.GenreDefinerService;
 
-import javax.transaction.Transactional;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,15 +27,24 @@ import java.util.regex.Pattern;
  * если не находит то обращается music.yandex.com
  */
 @Service
-@Transactional
 public class GenreDefinerServiceImpl implements GenreDefinerService {
     private final static Logger LOGGER = LoggerFactory.getLogger(GenreDefinerServiceImpl.class);
+    private final RestTemplate restTemplate;
+
+    @Value("${lastfm.url.getToptags}")
+    private String getTopTags;
+
+    @Autowired
+    public GenreDefinerServiceImpl(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
 
     @Override
-    public String[] defineGenre(String trackName) throws IOException {
-        String query1 = trackName;
+    public String[] defineGenre(String trackAuthor, String trackSong) throws IOException {
+        String trackName = trackAuthor + " - " + trackSong;
         String query2 = " жанр";
-        String url = "https://www.google.ru/search?q=" + query1 + query2;
+        String url = "https://www.google.ru/search?q=" + trackName + query2;
         String genre = "неизвестно";
         Document doc;
 
@@ -48,9 +65,9 @@ public class GenreDefinerServiceImpl implements GenreDefinerService {
         }
         LOGGER.debug("Genre result found so far = {}", genre);
 
-        if (genre.equals("неизвестно")) {      //для поиска жанра исполнетелей иностранных песен меняется стиль зап
+        if (genre.equals("неизвестно")) {      //для поиска жанра исполнителей иностранных песен меняется стиль зап
             query2 = " genre";
-            url = "https://www.google.ru/search?q=" + query1 + query2 + "&num=10";
+            url = "https://www.google.ru/search?q=" + trackName + query2 + "&num=10";
 
             try {
                 LOGGER.debug("Finding genre for '{}'. Google searching for '{}'", trackName, url);
@@ -70,64 +87,22 @@ public class GenreDefinerServiceImpl implements GenreDefinerService {
             LOGGER.debug("Genre result found so far = {}", genre);
         }
         if (genre.equals("неизвестно")) {
-            genre = defineGenreByAuthor(trackName); //если поиск жанра неудачно через google.ru, пытаемся узнать через music.yandex.com
+            return getGenreLastFm(trackAuthor, trackSong); //если поиск жанра не удался через google.ru, берем два топовых тега из ласт.фм
         }
         LOGGER.debug("Final search result is = {}", genre);
 
-        return getGenres(genre); //фильтр от "муссора"
-    }
-
-    public String defineGenreByAuthor(String trackName) throws IOException {
-        String query1 = trackName;
-        String url = "https://music.yandex.com/search?text=" + query1 + "&type=artists";
-        String genre = "неизвестно";
-        Document doc;
-
-        try {
-            LOGGER.debug("Finding genre for '{}'. Yandex searching for '{}'", trackName, url);
-            doc = Jsoup
-                    .connect(url)
-                    .userAgent("Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.0.1043 Yowser/2.5 Safari/537.36")
-                    .header("Accept-Language", "ru")
-                    .header("Accept-Encoding", "gzip, deflate, br")
-                    .timeout(10000).get();
-
-            genre = doc.getElementsByClass("d-genres").first().text();
-        } catch (HttpStatusException | NullPointerException e) {
-            LOGGER.debug("Didn't find anything, caught NullPointerException!");
-        }
-        LOGGER.debug("Genre result found so far = {}", genre);
-
-        if (genre.equals("неизвестно")) {
-            String artistName = query1.split(" – ")[0];
-            url = "https://music.yandex.com/search?text=" + artistName + "&type=artists";
-
-            try {
-                LOGGER.debug("Finding genre for '{}'. Yandex searching for '{}'", trackName, url);
-                doc = Jsoup
-                    .connect(url)
-                    .userAgent("Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.0.1043 Yowser/2.5 Safari/537.36")
-                    .header("Accept-Language", "ru")
-                    .header("Accept-Encoding", "gzip, deflate, br")
-                    .timeout(10000).get();
-
-                genre = doc.getElementsByClass("d-genres").first().text();
-            } catch (HttpStatusException | NullPointerException e) {
-                LOGGER.debug("Didn't find anything, caught NullPointerException!");
-            }
-            LOGGER.debug("Genre result found so far = {}", genre);
-        }
-        return genre;
+        return filterGenres(genre); // фильтр от "мусора"
     }
 
     /**
      * Возможны несколько стилей у одной песни.
      * Поисковики выдают различные ответы с различными приписками к жанрам
      * Очищаем от "мусора" и возвращаем массив строк с названием жанров
+     *
      * @param genre
      * @return
      */
-    public String[] getGenres(String genre) {
+    private String[] filterGenres(String genre) {
         LOGGER.debug("Extracting Genres[] out of string = {}", genre);
         genre = genre.replaceAll("\\s", "");
         LOGGER.debug("  1) String = {}", genre);
@@ -147,6 +122,39 @@ public class GenreDefinerServiceImpl implements GenreDefinerService {
         LOGGER.debug("  4) Resulting Genres[] are = {}", Arrays.asList(genres));
 
         return genres;
+    }
+
+    /**
+     * Получение данных о жанре композиции с помощью last.fm api, используя
+     * метод track.getTopTags: получаем ответ с телом в формате json.
+     * Заголовок "user-agent" и Thread.sleep() позволяет снизить шанс бана.
+     */
+    private String[] getGenreLastFm(String trackAuthor, String trackSong) throws IOException {
+        List<String> genreTags = new ArrayList<>();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("user-agent", "pacman_player");
+        HttpEntity request = new HttpEntity(headers);
+//        Thread.sleep(250);
+        ResponseEntity<String> response = restTemplate.exchange(getTopTags, HttpMethod.GET, request, String.class, trackAuthor, trackSong);
+        // берем из json имена первых 2 тегов, которые в 95% случаев являются жанрами композиции
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(response.getBody());
+        JsonNode tagsFields = root.get("toptags").get("tag");
+        if (tagsFields.size() > 0) {
+            try {
+                Iterator<JsonNode> elements = tagsFields.elements();
+                for (int i = 0; i < 2; i++) {
+                    JsonNode next = elements.next();
+                    genreTags.add(next.get("name").asText());
+                }
+            } catch (NoSuchElementException e) {
+                // у малопопулярных треков может быть меньше двух тегов
+            }
+        } else {
+            genreTags.add("неизвестный жанр");
+        }
+        LOGGER.debug("Resulting Genres[] are = {}", genreTags);
+        return genreTags.toArray(new String[0]);
     }
 
 }

--- a/src/main/java/spring/app/service/impl/SongServiceImpl.java
+++ b/src/main/java/spring/app/service/impl/SongServiceImpl.java
@@ -31,7 +31,7 @@ public class SongServiceImpl extends AbstractServiceImpl<Long, Song, SongDao> im
     private final CounterDao counterDao;
 
     @Autowired
-    public SongServiceImpl(SongDao dao, SongDtoDao songDtoDao, TagDao tagDao, CounterDao counterDao
+    public SongServiceImpl(SongDao dao, SongDtoDao songDtoDao, TagDao tagDao, CounterDao counterDao,
                            SongCompilationService songCompilationService, SongFileService songFileService) {
         super(dao);
         this.songDtoDao = songDtoDao;

--- a/src/main/java/spring/app/service/impl/SongServiceImpl.java
+++ b/src/main/java/spring/app/service/impl/SongServiceImpl.java
@@ -3,9 +3,11 @@ package spring.app.service.impl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import spring.app.dao.abstraction.CounterDao;
 import spring.app.dao.abstraction.SongDao;
 import spring.app.dao.abstraction.dto.SongDtoDao;
 import spring.app.dto.SongDto;
+import spring.app.model.Counter;
 import spring.app.model.Song;
 import spring.app.model.SongCompilation;
 import spring.app.service.abstraction.SongCompilationService;
@@ -23,13 +25,16 @@ public class SongServiceImpl extends AbstractServiceImpl<Long, Song, SongDao> im
     private final SongDtoDao songDtoDao;
     private final SongCompilationService songCompilationService;
     private final SongFileService songFileService;
+    private final CounterDao counterDao;
 
     @Autowired
-    public SongServiceImpl(SongDao dao, SongDtoDao songDtoDao, SongCompilationService songCompilationService, SongFileService songFileService) {
+    public SongServiceImpl(SongDao dao, SongDtoDao songDtoDao, SongCompilationService songCompilationService,
+                           SongFileService songFileService, CounterDao counterDao) {
         super(dao);
         this.songDtoDao = songDtoDao;
         this.songCompilationService = songCompilationService;
         this.songFileService = songFileService;
+        this.counterDao = counterDao;
     }
 
     @Override
@@ -102,6 +107,13 @@ public class SongServiceImpl extends AbstractServiceImpl<Long, Song, SongDao> im
     @Override
     public Long getAuthorIdBySongId(Long songId) {
         return dao.getAuthorIdBySongId(songId);
+    }
+
+    @Override
+    public void resetSongCounter(long songId) {
+        SongDto dto = songDtoDao.getById(songId);
+        String trackName = dto.getAuthorName().toUpperCase() + " - " + dto.getName().toUpperCase();
+        counterDao.restart(trackName);
     }
 
     @Override

--- a/src/main/java/spring/app/service/impl/musicSearcher/MusicSearchServiceImpl.java
+++ b/src/main/java/spring/app/service/impl/musicSearcher/MusicSearchServiceImpl.java
@@ -79,19 +79,19 @@ public class MusicSearchServiceImpl implements MusicSearchService {
     }
 
     //определяет жанр песни
-    public String[] getGenre(String trackName) throws IOException {
-        return genreDefiner.defineGenre(trackName);
+    private String[] getGenre(String author, String trackSong) throws IOException {
+        return genreDefiner.defineGenre(author, trackSong);
     }
 
     //заносит данные скачаной песни в бд и возвращает id песни
     public Long updateData(Track track) throws IOException {
-        String[] genreNames = getGenre(track.getFullTrackName());
+        String[] genreNames = getGenre(track.getAuthor(), track.getSong());
         return dataUpdater.updateData(track.getAuthor(), track.getSong(), genreNames);
     }
 
     //заносит данные песни из папки при инициализации в бд и возвращает id песни
     public Long updateData(String fullTrackName, String author, String songName) throws IOException {
-        String[] genreNames = getGenre(fullTrackName);
+        String[] genreNames = getGenre(track.getAuthor(), track.getSong());
         return dataUpdater.updateData(author, songName, genreNames);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,8 @@ server.tomcat.uri-encoding=UTF-8
 lastfm.key=4bdfccf57e8e4f48644b9353cc100874
 # url для методов track
 lastfm.url.getToptags=http://ws.audioscrobbler.com/2.0/?method=track.gettoptags&artist={a}&track={t}&api_key=4bdfccf57e8e4f48644b9353cc100874&format=json
+# google urls
+google.search.genre.en=https://www.google.ru/search?q=%s+genre&num=10
 # Батчинг (пакетная обработка).
 # Пакетная обработка позволяет нам отправлять группу операторов SQL в
 # базу данных за один вызов. Таким образом, мы можем оптимизировать

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,10 @@ spring.http.multipart.max-file-size=-1
 spring.http.encoding.charset=UTF-8
 spring.http.encoding.enabled=true
 server.tomcat.uri-encoding=UTF-8
+# last.fm API test data (ключ подставляется в каждый запрос)
+lastfm.key=4bdfccf57e8e4f48644b9353cc100874
+# url для методов track
+lastfm.url.getToptags=http://ws.audioscrobbler.com/2.0/?method=track.gettoptags&artist={a}&track={t}&api_key=4bdfccf57e8e4f48644b9353cc100874&format=json
 # Батчинг (пакетная обработка).
 # Пакетная обработка позволяет нам отправлять группу операторов SQL в
 # базу данных за один вызов. Таким образом, мы можем оптимизировать


### PR DESCRIPTION
Жду комментариев по поводу аннотаций над методами CounterDao
Ресет счетчика вынесен в approveSongQueue для того, чтобы не менять СЛИШКОМ много в приложении. 
Существует небольшой "баг" с тем, что в базе копятся счетчики с неправильными названиями песен от пользователей, но с другой стороны при такой архитектуре, поиск "несуществующих" треков будет выполняться не с первого сервиса, что уменьшит время ответа. Плюс дропнуть таблицу со счетчиком можно без какого-либо ущерба, ведь "правильные" треки уже будут скачанные.
Поменял в фабрике сет на лист для удобства работы с индексами. Я так понял сет там был для того, чтобы "не было дубликатов", но в чем сакральный смысл этой фичи я не догнал.
